### PR TITLE
Add logic to select correct `git` on macOS

### DIFF
--- a/source/git.py
+++ b/source/git.py
@@ -1,11 +1,19 @@
+import platform
 import subprocess
 from pathlib import Path
 from typing import Optional
 
+if platform.system() == "Darwin":
+    gitTool = "/opt/homebrew/bin/git "
+    gitCITool = "/opt/homebrew/bin/git-citool "
+else:
+    gitTool = "git "
+    gitCITool = "git citool"
+
 
 def __run(command: str, cwd: Path) -> str:
     process = subprocess.Popen(
-        "git " + command,
+        gitTool + command,
         cwd=cwd,
         shell=True,
         stdout=subprocess.PIPE,
@@ -38,7 +46,7 @@ def toplevel(path: Path) -> Optional[Path]:
 
 
 def citool(repo_dir: Path) -> None:
-    subprocess.Popen("git citool", cwd=repo_dir, shell=True)
+    subprocess.Popen(gitCITool, cwd=repo_dir, shell=True)
 
 
 __all__ = ["version", "toplevel", "citool"]


### PR DESCRIPTION
Subprocess on macOS uses the system path and not the user CLI environment path.  So, Apple's own Git version at `/usr/bin` will be preferred to a user installed version unless the path is made explicit. Most people use a CLI package manager such as 'Homebrew' to install and manage their own binary versions - eg `git citool` To access any user installed binaries, the full path must be enumerated i.e `/opt/homebrew/bin/git`

This solution works for me using Homebrew installed binaries, MacPorts installs elsewhere and I have not extended this. Note, there is no error checking here for path validity.